### PR TITLE
move google analytics to config.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ gem 'middleman-autoprefixer', '~> 2.7'
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 gem 'wdm', '~> 0.1', platforms: [:mswin, :mingw]
 gem "middleman-livereload", "~> 3.4.3"
+gem 'middleman-google-analytics', '~> 3.0'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,11 @@ GEM
       servolux
       tilt (~> 2.0)
       uglifier (~> 3.0)
+    middleman-google-analytics (3.0.0)
+      activesupport (>= 4.1, < 5.1)
+      erubis
+      middleman-core (>= 3.4)
+      uglifier (>= 2.5, < 4.0)
     middleman-livereload (3.4.6)
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
@@ -114,9 +119,10 @@ PLATFORMS
 DEPENDENCIES
   middleman (~> 4.2)
   middleman-autoprefixer (~> 2.7)
+  middleman-google-analytics (~> 3.0)
   middleman-livereload (~> 3.4.3)
   tzinfo-data
   wdm (~> 0.1)
 
 BUNDLED WITH
-   1.15.1
+   1.16.1

--- a/config.rb
+++ b/config.rb
@@ -7,6 +7,9 @@ end
 
 activate :livereload, host: '138.197.200.236'
 activate :directory_indexes
+activate :google_analytics do |ga|
+  ga.tracking_id = 'UA-1619676-7' # Replace with your property ID.
+end
 # Layouts
 # https://middlemanapp.com/basics/layouts/
 

--- a/source/_analytics.erb
+++ b/source/_analytics.erb
@@ -1,7 +1,0 @@
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-1619676-7"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'UA-1619676-7');
-</script>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -6,9 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="Kyle Tress">
     <title><%= current_page.data.title %> - Kyle Tress</title>
-    <%= partial 'analytics' %>
+    <%= google_analytics_tag if build? %>
     <%= stylesheet_link_tag "site" %>
-    <%= javascript_include_tag "site" %>
   </head>
   <body>
     <div class="container">


### PR DESCRIPTION
This PR move Google Analytics out of a custom partial and into the `config.rb` file, using the `middleman-google-analytics` gem. 